### PR TITLE
修复了VnTrader发现的两个bug

### DIFF
--- a/vnTrader/gateway/quantosGateway.py
+++ b/vnTrader/gateway/quantosGateway.py
@@ -585,7 +585,7 @@ class QuantOSTdApi(object):
         if not self.api:
             return
 
-        result, msg = self.api.cancel_order(cancelOrderReq.orderID)
+        taskid, msg = self.api.cancel_order(cancelOrderReq.orderID)
 
         if not check_return_error(taskid, msg):
             self.writeLog(u'撤单失败，错误信息：%s' %msg)

--- a/vnTrader/uiBasicWidget.py
+++ b/vnTrader/uiBasicWidget.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     from PyQt5 import QtGui, QtCore
     from PyQt5.QtWidgets import QTableWidgetItem, QTableWidget, QFrame, QLabel, QLineEdit, QComboBox, QDoubleSpinBox, \
-        QSpinBox, QCheckBox, QGridLayout, QHBoxLayout, QVBoxLayout, QPushButton, QMenu, QAction, QHeaderView
+        QSpinBox, QCheckBox, QGridLayout, QHBoxLayout, QVBoxLayout, QPushButton, QMenu, QAction, QHeaderView,QFileDialog
 
 from eventEngine import *
 from vtFunction import *
@@ -401,15 +401,15 @@ class BasicMonitor(QTableWidget):
         self.menu.close()
         
         # 获取想要保存的文件名
-        path = QtGui.QFileDialog.getSaveFileName(self, '保存数据', '', 'CSV(*.csv)')
+        path = QFileDialog.getSaveFileName(self, '保存数据', '', 'CSV(*.csv)')[0]
         
         try:
-            if not path.isEmpty():
-                with open(safeUnicode(path), 'wb') as f:
+            if path != '':
+                with open(safeUnicode(path), 'w') as f:
                     writer = csv.writer(f)
                     
                     # 保存标签
-                    headers = [header.encode('gbk') for header in self.headerList]
+                    headers = [header for header in self.headerList]
                     writer.writerow(headers)
                     
                     # 保存每行内容
@@ -419,7 +419,7 @@ class BasicMonitor(QTableWidget):
                             item = self.item(row, column)
                             if item is not None:
                                 rowdata.append(
-                                        safeUnicode(item.text()).encode('gbk'))
+                                        safeUnicode(item.text()))
                             else:
                                 rowdata.append('')
                         writer.writerow(rowdata)


### PR DESCRIPTION

## 1  saveToCsv函数调用QFileDialog出错
![tim 20180202173732](https://user-images.githubusercontent.com/31505997/35726475-ff6a1d06-083f-11e8-89a5-807013586430.png)

我使用的是Anaconda最新的版本，pytohn3.6，自带的PyQt5版本为5.10
在PyQt5中QFileDialog从PyQt.QtGui里移动到了PyQt5.QtWidgets里
[http://pyqt.sourceforge.net/Docs/PyQt5/api/qfiledialog.html](url)
![tim 20180202173147](https://user-images.githubusercontent.com/31505997/35726204-f9fc5560-083e-11e8-9b16-73ee1fb19e84.png)
新的QFileDialog返回的是一个元祖，第一个元素为路径字符串，第二个元素为文件类型字符串

原本的headers为一个list
headers = [header.encode('gbk') for header in self.headerList]
打开文件为二进制不支持写入list，会报错
with open(safeUnicode(path), 'wb') as f:

故改为了打开为文本文件：
with open(safeUnicode(path), 'w') as f:
不encode直接写入
headers = [header for header in self.headerList]

## 2  cancelOrder函数中api.cancel_order的返回值变量名取错了
把result改成了taskid